### PR TITLE
fix: bundle React 19 correctly in production build

### DIFF
--- a/configs/webpack/prod.js
+++ b/configs/webpack/prod.js
@@ -1,4 +1,9 @@
 // production config
+// Babel decides the JSX runtime (jsx vs jsxDEV) from BABEL_ENV/NODE_ENV,
+// which webpack's `mode` does not set for the build process itself.
+process.env.BABEL_ENV = 'production'
+process.env.NODE_ENV = 'production'
+
 const { resolve } = require('path')
 
 const { merge } = require('webpack-merge')
@@ -13,8 +18,4 @@ module.exports = merge(commonConfig, {
     publicPath: '/gpx-elevation-profile/',
   },
   devtool: 'source-map',
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM',
-  },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpx-elevation-profile",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gpx-elevation-profile",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpx-elevation-profile",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "aoisupersix",
   "license": "MIT",
   "repository": {

--- a/src/index.html.ejs
+++ b/src/index.html.ejs
@@ -9,14 +9,5 @@
     </head>
     <body>
         <div id="root"></div>
-
-        <!-- Dependencies -->
-        <% if (webpackConfig.mode == 'production') { %>
-        <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-        <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-        <% } else { %>
-        <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-        <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-        <% } %>
     </body>
 </html>


### PR DESCRIPTION
## Summary

The GitHub Pages deployment of v0.3.0 rendered a blank page, crashing at module init with:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'S')
    at react-dom-client.production.js:3165
```

Two production-build defects introduced by the React 19 upgrade:

1. **React 18 CDN / react-dom 19 bundle mismatch** — the prod webpack config mapped `react`/`react-dom` to UMD globals loaded from unpkg (pinned to React 18), but webpack object externals only match exact request strings, so `react-dom/client` was not externalized and pulled react-dom 19.2.7 into the bundle. Its module init reads React 19 internals (`__CLIENT_INTERNALS_...`) from the global React 18, which lacks them → the reported TypeError.
2. **Development JSX runtime in the production bundle** — Babel 8's `@babel/preset-react` picks the JSX runtime from `BABEL_ENV`/`NODE_ENV`, which webpack's `mode` does not set for the build process. Builds therefore emitted `jsxDEV` calls, and React 19's production `jsx-dev-runtime` does not implement `jsxDEV`, so the app would crash on first render even after fixing (1).

## Changes

- Remove the `react`/`react-dom` externals from the prod webpack config and the unpkg `<script>` tags from `index.html.ejs`, bundling React 19 instead (React 19 no longer ships UMD builds, so the CDN-globals approach cannot be kept)
- Set `BABEL_ENV`/`NODE_ENV=production` at the top of the prod webpack config (same pattern as CRA) so Babel emits the production JSX runtime
- Bump version to v0.3.1 so the publish workflow deploys and tags (v0.3.0 tag already exists, which skips publishing)

## Verification

- `npm run build`: dist HTML no longer references unpkg; the bundle contains only react/react-dom 19.2.7 and no `jsxDEV` references
- jsdom smoke test loading the built production bundle: no errors, app mounts into `#root` (previously reproduced both the `reading 'S'` crash and the `jsxDEV is not a function` crash)
- `npm run lint` / `npm test` pass