### PR TITLE
feat: add video start delay and preview playback controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpx-elevation-profile",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gpx-elevation-profile",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpx-elevation-profile",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "aoisupersix",
   "license": "MIT",
   "repository": {

--- a/src/components/ChartAnimationPreview.tsx
+++ b/src/components/ChartAnimationPreview.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import ReplayIcon from '@mui/icons-material/Replay'
+import StopIcon from '@mui/icons-material/Stop'
 import { Box, Button, LinearProgress, Stack } from '@mui/material'
 import { Chart, ChartConfiguration } from 'chart.js'
 
@@ -149,6 +150,14 @@ export const ChartAnimationPreview: React.FC<ChartAnimationPreviewProps> = (
         stopAnimation,
     ])
 
+    // Abort playback and restore the completed (fully revealed) chart.
+    const stop = React.useCallback(() => {
+        stopAnimation()
+        renderReveal(fullDataRef.current.length)
+        setProgressPercent(0)
+        setIsPlaying(false)
+    }, [renderReveal, stopAnimation])
+
     return (
         <Stack spacing={1}>
             <Box
@@ -169,9 +178,23 @@ export const ChartAnimationPreview: React.FC<ChartAnimationPreviewProps> = (
                     variant="outlined"
                     startIcon={hasPlayed ? <ReplayIcon /> : <PlayArrowIcon />}
                     onClick={play}
-                    disabled={props.disabled || isPlaying}
+                    disabled={props.disabled}
                 >
-                    {hasPlayed ? 'もう一度再生' : 'プレビュー再生'}
+                    {isPlaying
+                        ? '最初から再生'
+                        : hasPlayed
+                          ? 'もう一度再生'
+                          : 'プレビュー再生'}
+                </Button>
+                <Button
+                    size="small"
+                    variant="outlined"
+                    color="inherit"
+                    startIcon={<StopIcon />}
+                    onClick={stop}
+                    disabled={props.disabled || !isPlaying}
+                >
+                    中断
                 </Button>
                 <LinearProgress
                     variant="determinate"

--- a/src/components/ChartAnimationPreview.tsx
+++ b/src/components/ChartAnimationPreview.tsx
@@ -9,6 +9,8 @@ import { revealCountAt, revealedData } from '../models/chart-export'
 
 interface ChartAnimationPreviewProps {
     config: ChartConfiguration<'bar'>
+    /** Seconds the initial (pre-animation) frame is held before revealing. */
+    startDelaySec: number
     /** Seconds spent revealing the bars from left to right. */
     animationSec: number
     /** Seconds the completed graph stays on screen after the animation. */
@@ -104,7 +106,8 @@ export const ChartAnimationPreview: React.FC<ChartAnimationPreviewProps> = (
         setIsPlaying(true)
         setHasPlayed(true)
 
-        const totalSec = props.animationSec + props.holdSec
+        const totalSec =
+            props.startDelaySec + props.animationSec + props.holdSec
         let startTime: number | null = null
 
         const step = (now: number) => {
@@ -112,8 +115,13 @@ export const ChartAnimationPreview: React.FC<ChartAnimationPreviewProps> = (
                 startTime = now
             }
             const elapsedSec = (now - startTime) / 1000
+            const animationElapsedSec = elapsedSec - props.startDelaySec
             const revealProgress =
-                props.animationSec > 0 ? elapsedSec / props.animationSec : 1
+                animationElapsedSec <= 0
+                    ? 0
+                    : props.animationSec > 0
+                      ? animationElapsedSec / props.animationSec
+                      : 1
             const revealCount =
                 revealProgress >= 1
                     ? fullDataRef.current.length
@@ -133,7 +141,13 @@ export const ChartAnimationPreview: React.FC<ChartAnimationPreviewProps> = (
         }
 
         rafRef.current = requestAnimationFrame(step)
-    }, [props.animationSec, props.holdSec, renderReveal, stopAnimation])
+    }, [
+        props.startDelaySec,
+        props.animationSec,
+        props.holdSec,
+        renderReveal,
+        stopAnimation,
+    ])
 
     return (
         <Stack spacing={1}>

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -69,6 +69,7 @@ export const ExportPanel: React.FC<ExportPanelProps> = (props) => {
         defaultResolution.height,
     )
     const [videoFps, setVideoFps] = React.useState<number>(defaultFps)
+    const [startDelaySec, setStartDelaySec] = React.useState(2)
     const [animationSec, setAnimationSec] = React.useState(2)
     const [holdSec, setHoldSec] = React.useState(15)
     const [isRecording, setIsRecording] = React.useState(false)
@@ -80,7 +81,11 @@ export const ExportPanel: React.FC<ExportPanelProps> = (props) => {
     const canExport =
         format === 'png'
             ? sizeIsValid
-            : sizeIsValid && animationSec > 0 && holdSec >= 0 && !isRecording
+            : sizeIsValid &&
+              startDelaySec >= 0 &&
+              animationSec > 0 &&
+              holdSec >= 0 &&
+              !isRecording
 
     const onSelectPreset = (label: string) => {
         setPresetLabel(label)
@@ -138,6 +143,7 @@ export const ExportPanel: React.FC<ExportPanelProps> = (props) => {
                 width: exportWidth,
                 height: exportHeight,
                 fps: videoFps,
+                startDelaySec,
                 animationSec,
                 holdSec,
                 fileName: 'elevation-graph.mp4',
@@ -288,6 +294,23 @@ export const ExportPanel: React.FC<ExportPanelProps> = (props) => {
                         </TextField>
                         <TextField
                             type="number"
+                            label="開始前の待機時間"
+                            size="small"
+                            value={startDelaySec}
+                            onChange={(e) =>
+                                setStartDelaySec(
+                                    parseNonNegativeNumber(e.target.value),
+                                )
+                            }
+                            slotProps={{
+                                input: { endAdornment: secondsAdornment },
+                            }}
+                            helperText="アニメーション開始前に静止表示する時間"
+                            sx={{ width: 180 }}
+                            disabled={isRecording}
+                        />
+                        <TextField
+                            type="number"
                             label="アニメーション時間"
                             size="small"
                             value={animationSec}
@@ -335,6 +358,7 @@ export const ExportPanel: React.FC<ExportPanelProps> = (props) => {
                     </Typography>
                     <ChartAnimationPreview
                         config={props.config}
+                        startDelaySec={startDelaySec}
                         animationSec={animationSec}
                         holdSec={holdSec}
                         aspectRatio={exportWidth / exportHeight}

--- a/src/models/chart-export.ts
+++ b/src/models/chart-export.ts
@@ -185,6 +185,8 @@ export interface VideoExportOptions {
     width: number
     height: number
     fps: number
+    /** Seconds the initial (pre-animation) frame is held before revealing. */
+    startDelaySec: number
     /** Seconds spent revealing the bars from left to right. */
     animationSec: number
     /** Seconds the completed graph stays on screen after the animation. */
@@ -209,6 +211,7 @@ export const exportChartMp4 = async (
         width,
         height,
         fps,
+        startDelaySec,
         animationSec,
         holdSec,
         fileName,
@@ -246,9 +249,10 @@ export const exportChartMp4 = async (
         videoHeight,
     )
     const fullData = [...(chart.data.datasets[0].data as number[])]
+    const delayFrames = Math.max(0, Math.round(fps * startDelaySec))
     const animationFrames = Math.max(1, Math.round(fps * animationSec))
     const holdFrames = Math.max(0, Math.round(fps * holdSec))
-    const totalFrames = animationFrames + holdFrames
+    const totalFrames = delayFrames + animationFrames + holdFrames
     const frameDuration = Math.round(1_000_000 / fps)
 
     const muxer = new Muxer({
@@ -284,12 +288,14 @@ export const exportChartMp4 = async (
             }
 
             const revealCount =
-                frame < animationFrames
-                    ? revealCountAt(
-                          fullData.length,
-                          (frame + 1) / animationFrames,
-                      )
-                    : fullData.length
+                frame < delayFrames
+                    ? revealCountAt(fullData.length, 0)
+                    : frame < delayFrames + animationFrames
+                      ? revealCountAt(
+                            fullData.length,
+                            (frame - delayFrames + 1) / animationFrames,
+                        )
+                      : fullData.length
             chart.data.datasets[0].data = revealedData(fullData, revealCount)
             chart.update('none')
 


### PR DESCRIPTION
## Summary

Adds two improvements to the MP4 export experience:

1. **Configurable start delay** — the exported video (and preview) can now hold the initial pre-animation frame for a configurable number of seconds before the reveal starts.
2. **Preview playback controls** — the preview play button stays enabled during playback so it can restart from the beginning, and a new stop button aborts playback and restores the completed chart.

## Changes

- Add a 開始前の待機時間 (start delay) field to the video settings, threaded through `exportChartMp4` and `ChartAnimationPreview`
- Keep the preview play button enabled while playing (restarts the animation from the beginning; label switches to 最初から再生)
- Add a 中断 (stop) button that cancels the animation frame loop, restores the fully revealed chart, and resets the progress bar
- Bump version to v0.4.0 so the publish workflow deploys and tags

## Verification

- `npm run lint` / `npm test` / `npm run build` all pass locally
- `tsc --noEmit` reports no errors